### PR TITLE
date_added for quota changed to a timestamp field

### DIFF
--- a/mysql.sql
+++ b/mysql.sql
@@ -84,7 +84,7 @@ CREATE TABLE quota (
   is_regex tinyint(1) DEFAULT '0',
   profile bigint(20) unsigned NOT NULL,
   instigator bigint(20) unsigned DEFAULT NULL,
-  date_added datetime DEFAULT NULL,
+  date_added timestamp DEFAULT CURRENT_TIMESTAMP,
   UNIQUE KEY id (id),
   UNIQUE KEY selector (selector,value,profile),
   KEY profile (profile),


### PR DESCRIPTION
date_added in the Quota table should be a timestamp with a default of current_timestamp. This way, the application using it isn't bothered with actually setting the column on insert.

Arguably the name of date_added could be changed to timestamp_added or something like that.
