### PR TITLE
add selector to abuser stats + add session data in search response

### DIFF
--- a/assets/htmlTemplates/abusers.html
+++ b/assets/htmlTemplates/abusers.html
@@ -23,6 +23,11 @@
                 {{ end }}
             </select>
         </div>
+        <div class="form-group">
+            <label for="selector">Selector</label>
+            <br>
+            <select id="" name="selector"><option value="sender_domain">Sender domain</option><option value="sasl_username">Sasl username</option></select>
+        </div>
        <button type="submit" class="btn btn-default">Show Abusers</button>
    </form>
 

--- a/mysql.sql
+++ b/mysql.sql
@@ -46,6 +46,7 @@ CREATE TABLE session (
   PRIMARY KEY (id),
   KEY cluegetter_instance (cluegetter_instance),
   KEY session_date (cluegetter_instance,date_connect),
+  KEY sasl_username (sasl_username),
   CONSTRAINT session_ibfk_1 FOREIGN KEY (cluegetter_instance) REFERENCES instance (id),
   CONSTRAINT session_ibfk_2 FOREIGN KEY (cluegetter_client) REFERENCES cluegetter_client (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;


### PR DESCRIPTION
This adds the following to cluegetter:
- Abuse reports based on sasl_username instead of sender_domain (since sasl_username has more importance to us)
- Session data to the response of a search request.
- A key to mysql for sasl_username since it may now be used for abuse reports
