### PR TITLE
Add sasl username to abuser report

### DIFF
--- a/DDL-Changes.sql
+++ b/DDL-Changes.sql
@@ -1,3 +1,6 @@
+-- v0.5.2
+ALTER TABLE session ADD KEY sasl_username (sasl_username);
+
 -- v0.4.3
 ALTER TABLE message_header CHANGE name name varbinary(74) not null,
                             CHANGE body body blob not null;

--- a/assets/htmlTemplates/abusers.html
+++ b/assets/htmlTemplates/abusers.html
@@ -23,24 +23,46 @@
                 {{ end }}
             </select>
         </div>
+        <div class="form-group">
+            <label for="selector">Selector</label><br />
+            <select name="selector">
+                {{ range $key, $selector := .Selectors }}
+                    {{ if $selector.Selected }}
+                    <option selected="selected" value="{{ $selector.Name }}">{{ $selector.Text }}</option>
+                    {{ else }}
+                    <option value="{{ $selector.Name }}">{{ $selector.Text }}</option>
+                    {{ end }}
+                {{ end }}
+            </select>
+        </div>
        <button type="submit" class="btn btn-default">Show Abusers</button>
    </form>
 
     <table class="table table-striped">
-        <tr>
-            <th>Sender Domain</th>
-            <th title="Sum of messages with status tempfail and status reject">Not accepted</th>
-        </tr>
-
-	{{ range $key, $senderDomain := .SenderDomainTop }}
-		<tr>
-<!--			<td><a href="/stats/sender-domain/{{ $senderDomain.Identifier }}" -->
-			<td><a href="/message/searchEmail/@{{ $senderDomain.Identifier }}"
-				>{{ $senderDomain.Identifier }}</td>
-			<td>{{ $senderDomain.Count }}</td>
-		</tr>
-	{{ end }}
-
+        <thead>
+            <tr>
+                <th>Sender Domain</th>
+                <th>Sasl Username</th>
+                <th title="Sum of messages with status tempfail and status reject">Not accepted</th>
+            </tr>
+        </thead>
+        <tbody>
+        {{ range $key, $senderDomain := .SenderDomainTop }}
+            <tr>
+                <td>
+                    <a href="/message/searchEmail/@{{ $senderDomain.SenderDomain }}">
+                        {{ $senderDomain.SenderDomain }}
+                    </a>
+                </td>
+                <td>
+                    <a href="/message/searchSaslUser/{{ $senderDomain.SaslUsername }}">
+                        {{ $senderDomain.SaslUsername }}
+                    </a>
+                </td>
+                <td>{{ $senderDomain.Count }}</td>
+            </tr>
+        {{ end }}
+        </tbody>
     </table>
 
 {{ end }}

--- a/mysql.sql
+++ b/mysql.sql
@@ -44,6 +44,7 @@ CREATE TABLE session (
   cipher varchar(255) charset ascii NOT NULL DEFAULT '',
   tls_version varchar(31) charset ascii NOT NULL DEFAULT '',
   PRIMARY KEY (id),
+  KEY sasl_username (sasl_username),
   KEY cluegetter_instance (cluegetter_instance),
   KEY session_date (cluegetter_instance,date_connect),
   CONSTRAINT session_ibfk_1 FOREIGN KEY (cluegetter_instance) REFERENCES instance (id),

--- a/src/cluegetter/http.go
+++ b/src/cluegetter/http.go
@@ -511,7 +511,7 @@ func httpGetSelectors(r *http.Request) (out []*httpAbuserSelector, err error) {
 	}
 
 	if !hasSelectedSelector && r.FormValue("selector") != "" {
-		return nil, errors.New("'" + r.FormValue("selector") + "' is not a valid value for parameter selector")
+		return nil, errors.New("Invalid selector specified: " + r.FormValue("selector"))
 	}
 
 	return selectors, nil


### PR DESCRIPTION
this PR adds
- option to select an selector for the abuse report, the current options are `sasl_username` and `sender_domain`
- the column `Sasl Username` to the abusers report
- A key to the `session` for the column `sasl_username`, for the grouping in the abusers report
