### PR TITLE
Fix the selected checkboxes in search results

### DIFF
--- a/assets/htmlTemplates/elasticsearch/search.html
+++ b/assets/htmlTemplates/elasticsearch/search.html
@@ -219,19 +219,19 @@
                         <label for="input-verdict-1" title="">
                             <input type="checkbox" name="verdict" value="1"
                                    id="input-verdict-1"
-                                   {{ range $k, $v := .Finder.Verdicts }}{{ if eq $v 0 }}checked="checked"{{end}}{{end}}
+                                   {{ range $k, $v := .Finder.Verdicts }}{{ if eq $v 1 }}checked="checked"{{end}}{{end}}
                             /> Tempfail
                         </label><br/>
                         <label for="input-verdict-2" title="">
                             <input type="checkbox" name="verdict" value="2"
                                    id="input-verdict-2"
-                                   {{ range $k, $v := .Finder.Verdicts }}{{ if eq $v 0 }}checked="checked"{{end}}{{end}}
+                                   {{ range $k, $v := .Finder.Verdicts }}{{ if eq $v 2 }}checked="checked"{{end}}{{end}}
                             /> Reject
                         </label>
                         <label for="input-verdict-3" title="">
                             <input type="checkbox" name="verdict" value="3"
                                    id="input-verdict-3"
-                                   {{ range $k, $v := .Finder.Verdicts }}{{ if eq $v 0 }}checked="checked"{{end}}{{end}}
+                                   {{ range $k, $v := .Finder.Verdicts }}{{ if eq $v 3 }}checked="checked"{{end}}{{end}}
                             /> Error
                         </label>
                     </li>


### PR DESCRIPTION
search.html checks whether or not a checkbox is selected or not. It should check for the value of the verdict checkbox that check is for, but it compared it with 0 instead of the actual value/id of the verdict.